### PR TITLE
Add pid property to Server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@typescript/server-harness",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@typescript/server-harness",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^14.18.12",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@typescript/server-harness",
   "author": "Microsoft Corp.",
   "homepage": "https://github.com/microsoft/typescript-server-harness#readme",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "license": "MIT",
   "description": "Communicate with a tsserver process",
   "keywords": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,8 @@ export interface Server {
     on(event: "exit", listener: ExitListener): void;
     /** Fires when the server closes (exits + closes IO streams). */
     on(event: "close", listener: CloseListener): void;
+    /** The PID of the subprocess. */
+    pid?: number;
 }
 
 /**
@@ -88,6 +90,7 @@ export function launchServer(tsserverPath: string, args?: string[], execArgv?: s
         exitOrKill: timeoutMs => exitOrKill(serverProc, useNodeIpc, timeoutMs),
         kill: () => kill(serverProc),
         on,
+        pid: serverProc.pid,
     };
 }
 


### PR DESCRIPTION
I'm planning to use this in ts-perf to set the CPU affinity on the server. Normally, I'd run `taskset` to do this, but because the harness does `fork` for IPC, it has to be applied externally.